### PR TITLE
fix: move QueryClientProvider to root element & added additional prov…

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,5 +1,4 @@
 import * as React from "react"
-import { QueryClient, QueryClientProvider } from "react-query"
 
 import { Navigation } from "../Navigation/Navigation"
 
@@ -7,8 +6,6 @@ export interface LayoutProps {
   pageTitle?: string
   children: React.ReactNode
 }
-
-const queryClient = new QueryClient()
 
 export const Layout = (props: LayoutProps) => {
   const { pageTitle, children } = props
@@ -19,10 +16,8 @@ export const Layout = (props: LayoutProps) => {
         <Navigation />
       </div>
       <main>
-        <QueryClientProvider client={queryClient}>
-          {heading}
-          {children}
-        </QueryClientProvider>
+        {heading}
+        {children}
       </main>
     </div>
   )

--- a/src/pages/edit.tsx
+++ b/src/pages/edit.tsx
@@ -1,12 +1,18 @@
 import React from "react"
+import { QueryClient, QueryClientProvider } from "react-query"
+
 import Edit from "../components/Edit/Edit"
 import Seo from "../components/Seo/Seo"
+
+const queryClient = new QueryClient()
 
 export default function EditPage({ location }: any) {
   return (
     <>
       <Seo title="Edit" />
-      <Edit recordData={location} />
+      <QueryClientProvider client={queryClient}>
+        <Edit recordData={location} />
+      </QueryClientProvider>
     </>
   )
 }

--- a/src/wrapPageElement.tsx
+++ b/src/wrapPageElement.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 
 import { Layout } from "./components/Layout/Layout"
-import { AuthProvider } from "./context/store"
 
 interface PageElementProps {
   element: React.ReactElement[] | React.ReactElement
@@ -13,9 +12,7 @@ const WrapPageElement: React.FC<PageElementProps> = ({
 }: PageElementProps) => {
   return (
     <>
-      <AuthProvider>
-        <Layout {...props}>{element}</Layout>
-      </AuthProvider>
+      <Layout {...props}>{element}</Layout>
     </>
   )
 }

--- a/src/wrapRootElement.tsx
+++ b/src/wrapRootElement.tsx
@@ -1,4 +1,9 @@
 import React from "react"
+import { QueryClient, QueryClientProvider } from "react-query"
+
+import { AuthProvider } from "./context/store"
+
+const queryClient = new QueryClient()
 
 interface RootElementProps {
   element: React.ReactElement[] | React.ReactElement
@@ -7,7 +12,15 @@ interface RootElementProps {
 const WrapRootElement: React.FC<RootElementProps> = ({
   element,
 }: RootElementProps) => {
-  return <>{element}</>
+  return (
+    <>
+      <AuthProvider>
+        <QueryClientProvider client={queryClient}>
+          {element}
+        </QueryClientProvider>
+      </AuthProvider>
+    </>
+  )
 }
 
 export default WrapRootElement


### PR DESCRIPTION
…ider in edit page

This was done to fix a build error stating No QueryClient set. Additionally, the AuthContext was also moved to the rootElement

Closes #97 